### PR TITLE
Add error display to Login

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -125,18 +125,6 @@ const App: React.FC = () => {
 
       <div className="container mt-3">
         <Routes>
-          {/* <Route path="/" element={<Home />} /> */}
-          {/* <Route
-            path="/"
-            element={
-              <>
-                <p>
-                  <Link to="/questions">Go to Questions</Link>
-                </p>
-              </>
-            }
-          /> */}
-          {/* <Route path="/home" element={<Home />} /> */}
           <Route path="/" element={<Home />} />
           <Route path="/login" element={<Login />} />
           <Route path="/register" element={<Register />} />

--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -13,7 +13,7 @@ type Props = {}
 
 const Login: React.FC<Props> = () => {
   let navigate: NavigateFunction = useNavigate();
-
+  const [loginError, setLoginError] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(false);
   const [message, setMessage] = useState<string>("");
 
@@ -121,7 +121,6 @@ const Login: React.FC<Props> = () => {
                 </label>
               </div>
               
-
               <div className="form-group mt-3 d-flex align-items-center">
               <div className="col-md-5" style={{ fontFamily: 'Inter, sans-serif', fontWeight: 'bold', color: 'rgba(0, 0, 0, 0.5)'  }}>
                 No Account?
@@ -147,6 +146,20 @@ const Login: React.FC<Props> = () => {
                   </button>
                 </div>
               </div>
+              {message && (
+                  <div className="form-group">
+                    <div
+                      className={
+                        loginError
+                          ? "alert alert-success"
+                          : "alert alert-danger"
+                      }
+                      role="alert"
+                    >
+                      {message}
+                    </div>
+                  </div>
+                )}
             </Form>
               )}
             </Formik>


### PR DESCRIPTION
This PR will

- Add error display when user logs in (message by user-service)
- Standardize error sent to user (by user-service)
- Sample as follows
<img width="200" alt="Screenshot 2023-10-11 at 10 42 30 AM" src="https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g06/assets/58366602/c1ba3cbf-a63c-4f82-b739-23526817a015">
<img width="200" alt="Screenshot 2023-10-11 at 10 42 48 AM" src="https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g06/assets/58366602/2813d24d-b144-4e1e-9945-25375619ff74">

