### PR TITLE
Change login error to be more ambiguous

### DIFF
--- a/user-service/controllers/auth.controller.js
+++ b/user-service/controllers/auth.controller.js
@@ -48,7 +48,7 @@ exports.signin = (req, res) => {
   })
     .then((user) => {
       if (!user) {
-        return res.status(404).send({ message: 'User Not found.' });
+        return res.status(404).send({ message: 'Invalid username or password' });
       }
 
       var passwordIsValid = bcrypt.compareSync(
@@ -59,7 +59,7 @@ exports.signin = (req, res) => {
       if (!passwordIsValid) {
         return res.status(401).send({
           accessToken: null,
-          message: 'Invalid Password!',
+          message: 'Invalid username or password',
         });
       }
 


### PR DESCRIPTION
This commit updates the error messages previously stating "User Not Found" and "Invalid Password" to a more secure and clear "Invalid username or password" message for login failures, reducing ambiguity and enhancing security.