### PR TITLE
Disable admin buttons for user

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -28,7 +28,6 @@ import logo from './images/peerPrepLogo.png';
 const App: React.FC = () => {
   const [showModeratorBoard, setShowModeratorBoard] = useState<boolean>(false);
   const [showAdminBoard, setShowAdminBoard] = useState<boolean>(false);
-  // const [currentUser, setCurrentUser] = useState<boolean>(false);
   const [currentUser, setCurrentUser] = useState<boolean>(() =>
     localStorage.getItem("user") ? true : false
   );

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -83,11 +83,19 @@ const App: React.FC = () => {
             </li>
           )}
 
-          {showAdminBoard && (
+          {/* {showAdminBoard && (
             <li className="nav-item">
               <Link to={"/admin"} className="nav-link">
                 Admin Board
               </Link>
+            </li>
+          )} */}
+          
+          {showAdminBoard && (
+            <li className="nav-item">
+              <span className="nav-link">
+                Admin
+              </span>
             </li>
           )}
 

--- a/frontend/src/Question/Question.tsx
+++ b/frontend/src/Question/Question.tsx
@@ -7,6 +7,7 @@ import DeleteIcon from "@mui/icons-material/Delete";
 import EditIcon from "@mui/icons-material/Edit";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import CircularProgress from "@mui/material/CircularProgress";
+import { getCurrentUser } from "../services/auth.service";
 
 import {
   Dialog,
@@ -87,6 +88,9 @@ export default function Question() {
   const [question, setQuestion] = useState<QuestionInt | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const navigate = useNavigate();
+
+  const currentUser = getCurrentUser();
+  const isAdmin = currentUser && currentUser.roles.includes("ROLE_ADMIN");
 
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false); // Confirmation dialog state
 
@@ -189,28 +193,32 @@ export default function Question() {
               </h1>
             </div>
             <div>
-              <Button
-                variant="contained"
-                style={{
-                  backgroundColor: "#6C63FF",
-                  borderRadius: "50px",
-                  fontSize: "15px",
-                  marginRight: "10px",
-                }}
-                onClick={handleUpdate}
-              >
-                <EditIcon />
-              </Button>
-              <Button
-                variant="contained"
-                style={{
-                  backgroundColor: "#FF6A6A",
-                  borderRadius: "20px",
-                }}
-                onClick={openDeleteDialog}
-              >
-                <DeleteIcon />
-              </Button>
+              {isAdmin && (
+                <>
+                  <Button
+                    variant="contained"
+                    style={{
+                      backgroundColor: "#6C63FF",
+                      borderRadius: "50px",
+                      fontSize: "15px",
+                      marginRight: "10px",
+                    }}
+                    onClick={handleUpdate}
+                  >
+                    <EditIcon />
+                  </Button>
+                  <Button
+                    variant="contained"
+                    style={{
+                      backgroundColor: "#FF6A6A",
+                      borderRadius: "20px",
+                    }}
+                    onClick={openDeleteDialog}
+                  >
+                    <DeleteIcon />
+                  </Button>
+                </>
+              )}
             </div>
           </Grid>
 

--- a/frontend/src/Table/Table.tsx
+++ b/frontend/src/Table/Table.tsx
@@ -16,6 +16,7 @@ import { useNavigate } from "react-router-dom";
 import { styled } from "@mui/material/styles";
 import "./Table.css";
 import CircularProgress from "@mui/material/CircularProgress";
+import { getCurrentUser } from "../services/auth.service";
 
 
 const AddButton = styled(Button)`
@@ -66,6 +67,9 @@ const BasicTable: React.FC = () => {
         console.error("Error fetching data:", error);
       });
   };
+
+  const currentUser = getCurrentUser();
+  const isAdmin = currentUser && currentUser.roles.includes("ROLE_ADMIN");
 
   useEffect(() => {
     const fetchData = async () => {
@@ -173,25 +177,27 @@ const BasicTable: React.FC = () => {
             onRowsPerPageChange={handleChangeRowsPerPage}
           />
         </Grid>
-        <Grid item xs={12}>
-        <AddButton
-          sx={{
-            position: 'fixed',
-            bottom: '30px',
-            right: '30px',
-            height: '30px',
-            fontSize: '25px',
-            borderRadius: '40px',
-            minWidth: '40px', // Set the minimum width
-            maxWidth: '40px',  // Set the maximum width
-          }}
-          variant="contained"
-          onClick={handleAddButtonClick}
-        >
-          +
-        </AddButton>
+        {isAdmin && (
+          <Grid item xs={12}>
+            <AddButton
+              sx={{
+                position: 'fixed',
+                bottom: '30px',
+                right: '30px',
+                height: '30px',
+                fontSize: '25px',
+                borderRadius: '40px',
+                minWidth: '40px',
+                maxWidth: '40px',
+              }}
+              variant="contained"
+              onClick={handleAddButtonClick}
+            >
+              +
+            </AddButton>
+          </Grid>
+        )}
 
-        </Grid>
       </Grid>
     </Container>
   );


### PR DESCRIPTION
This PR Will:
1. Add "Admin" word to top of nav bar for admin users
2. Disable "Add", "Edit" and "Delete" buttons for questions for non-admin users

Example:
**Admin View**
<img width="800" alt="Screenshot 2023-10-15 at 4 45 11 PM" src="https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g06/assets/58366602/8f1965aa-5f01-45fc-bf7f-79527fac9d02">
<img width="800" alt="Screenshot 2023-10-15 at 4 45 51 PM" src="https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g06/assets/58366602/89bdccf2-c357-4e9d-9609-8a2caee4d640">


**User View**
<img width="800" alt="Screenshot 2023-10-15 at 4 45 20 PM" src="https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g06/assets/58366602/98f3f0d7-af55-4cc3-8f1c-82dfade32911">
<img width="800" alt="Screenshot 2023-10-15 at 4 45 59 PM" src="https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g06/assets/58366602/f03b2fbd-b83f-438d-864a-3c37f062b4d0">
