### PR TITLE
Keep loading spinner up if question service is not up

### DIFF
--- a/frontend/src/Table/Table.tsx
+++ b/frontend/src/Table/Table.tsx
@@ -53,7 +53,6 @@ const BasicTable: React.FC = () => {
       })
       .catch((error) => {
         console.error("Error fetching data:", error);
-        setIsLoading(false);
       });
   };
 


### PR DESCRIPTION
This commit keeps the loading spinner up in case of question service failure.