### PR TITLE
Fix user-profile bug

### DIFF
--- a/frontend/src/components/Profile.tsx
+++ b/frontend/src/components/Profile.tsx
@@ -160,6 +160,7 @@ const Profile: React.FC = () => {
           setUserErrorMessage(err.response.data.message);
           setErrorType("user");
           setShowErrorModal(true);
+          resetForm();
         });
     },
     enableReinitialize: true,


### PR DESCRIPTION
This PR will fix a bug in frontend where after user chooses to change profile to an already existing username or password, the form doesn't get reset back to the user's original name.

Changing from user01 (current) to user02 (existing user in DB)
**Current**
![Screenshot 2023-11-02 at 10 54 01 PM](https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g06/assets/58366602/23e5b824-890c-4911-939b-90c22c318dcc)

**Fix**
![Screenshot 2023-11-02 at 10 54 23 PM](https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g06/assets/58366602/27d12aa6-2d0f-42e7-aecd-7eb44b3c38ad)
