### PR TITLE
Add admin-protected routes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import Register from "./components/Register";
 import Home from "./components/Home";
 import Profile from "./components/Profile";
 import Protected from "./components/Protected";
+import AdminProtected from "./components/AdminProtected/AdminProtected";
 import PageNotFound from "./components/PageNotFound/PageNotFound";
 import GuestRoute from "./components/GuestRoute";
 import EventBus from "./common/EventBus";
@@ -26,6 +27,7 @@ import Analytics from "./components/Analytics";
 import "./App.css";
 import "./Table/Table";
 import UserAttempt from "./UserAttempt/UserAttempt";
+import { getCurrentUser } from "./services/auth.service";
 
 const App: React.FC = () => {
   console.log("QNS_SVC: ", process.env.REACT_APP_QNS_SVC);
@@ -36,6 +38,11 @@ const App: React.FC = () => {
   const [currentUser, setCurrentUser] = useState<boolean>(() =>
     localStorage.getItem("user") ? true : false
   );
+
+  const [currentUserAccessToken, setCurrentUserAccessToken] = useState<string>(() => {
+    return getCurrentUser()?.accessToken || "";
+  });
+
   const location = useLocation(); // Get the current location
   const isCodeSpaceRoute = location.pathname.startsWith("/match/");
 
@@ -276,8 +283,11 @@ const App: React.FC = () => {
               </Protected>
             }
           />
-
-          <Route path="/questions/add-question" element={<AddQuestionForm />} />
+          <Route path="/questions/add-question" element={
+            <AdminProtected token={currentUserAccessToken}>
+              <AddQuestionForm />
+            </AdminProtected>
+            } />
           <Route path="*" element={<PageNotFound />} />
         </Routes>
       </div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -284,9 +284,11 @@ const App: React.FC = () => {
             }
           />
           <Route path="/questions/add-question" element={
-            <AdminProtected token={currentUserAccessToken}>
-              <AddQuestionForm />
-            </AdminProtected>
+            <Protected isLoggedIn={currentUser}>
+              <AdminProtected token={currentUserAccessToken}>
+                <AddQuestionForm />
+              </AdminProtected>
+            </Protected>
             } />
           <Route path="*" element={<PageNotFound />} />
         </Routes>

--- a/frontend/src/components/AdminProtected/AdminProtected.css
+++ b/frontend/src/components/AdminProtected/AdminProtected.css
@@ -1,0 +1,23 @@
+.spinner {
+    border: 30px solid rgba(0, 0, 0, 0.1);
+    width:200px;
+    height: 200px;
+    border-radius: 50%;
+    border-left-color: #09f;
+  
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    animation: spin 1s ease infinite;
+  }
+  
+  @keyframes spin {
+    0% {
+      transform: translate(-50%, -50%) rotate(0deg);
+    }
+    100% {
+      transform: translate(-50%, -50%) rotate(360deg);
+    }
+  }
+  

--- a/frontend/src/components/AdminProtected/AdminProtected.tsx
+++ b/frontend/src/components/AdminProtected/AdminProtected.tsx
@@ -1,0 +1,27 @@
+import React, { ReactNode } from 'react';
+import { Navigate } from 'react-router-dom';
+import useAdminCheck from './useAdminCheck';
+import Unauthorised from '../Unauthorised/Unauthorised';
+import './AdminProtected.css';  // Import your CSS here
+
+interface AdminProtectedProps {
+  token: string;
+  children: ReactNode;
+}
+
+const AdminProtected: React.FC<AdminProtectedProps> = ({ token, children }) => {
+  const { isAdmin, isLoading } = useAdminCheck(token);
+
+  if (isLoading) {
+    return <div className="spinner"></div>;
+  }
+
+  if (!isAdmin) {
+    // return <Navigate to="/login" replace />;
+    return <Unauthorised />;
+  }
+
+  return <>{children}</>;
+};
+
+export default AdminProtected;

--- a/frontend/src/components/AdminProtected/useAdminCheck.ts
+++ b/frontend/src/components/AdminProtected/useAdminCheck.ts
@@ -1,0 +1,31 @@
+import { useState, useEffect } from 'react';
+import axios from 'axios';
+
+const auth_server = process.env.REACT_APP_USR_SVC_AUTH;
+
+const useAdminCheck = (token: string) => {
+  const [isAdmin, setIsAdmin] = useState<boolean>(false);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    console.log(token);
+    axios.get(`${auth_server}/verifyAdmin`, {
+      headers: { 'x-access-token': token }
+    })
+    .then(response => {
+      setIsAdmin(response.status === 200);
+      console.log(response);
+    })
+    .catch((e) => {
+      setIsAdmin(false);
+      console.log(e);
+    })
+    .finally(() => {
+      setIsLoading(false);
+    });
+  }, [token]);
+
+  return { isAdmin, isLoading };
+};
+
+export default useAdminCheck;

--- a/frontend/src/components/Unauthorised/Unauthorised.tsx
+++ b/frontend/src/components/Unauthorised/Unauthorised.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const Unauthorised: React.FC = () => {
+  return (
+    <div>
+      <h1>Unauthorised!</h1>
+      <p>Sorry, you are not authorised to view this page.</p>
+    </div>
+  );
+};
+
+export default Unauthorised;


### PR DESCRIPTION
This PR will add admin route protection to add-question under the endpoint `/questions/add-question`

Previously, the route is not protected, meaning unauthorised and unauthenticated users can both go in.

**Admin - access**
![Screenshot 2023-11-03 at 12 19 28 AM](https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g06/assets/58366602/a5cbf854-3cac-4d84-bed4-51c4e1c41a18)
**User - no access**
![Screenshot 2023-11-03 at 12 19 43 AM](https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g06/assets/58366602/235c00cc-fa27-4ac8-84e8-7ad82374227a)
**Non-logged in - redirected to login**
![Screenshot 2023-11-03 at 12 22 23 AM](https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g06/assets/58366602/43246105-3a82-4315-9dbe-e21e0cd02fa5)

