### PR TITLE
Fix create question validation for soft delete

### DIFF
--- a/question-service/controllers/questionController.js
+++ b/question-service/controllers/questionController.js
@@ -65,8 +65,8 @@ module.exports = {
     const { title, frontendQuestionId, difficulty, content, category, topics } =
       req.body;
 
-    // Check if a question with the same title already exists
-    Question.findOne({ title })
+    // Check if a question with the same title already exists and not soft deleted
+    Question.findOne({ title, isDeleted: false })
       .then((existingQuestion) => {
         if (existingQuestion) {
           return res

--- a/question-service/controllers/questionController.js
+++ b/question-service/controllers/questionController.js
@@ -107,8 +107,8 @@ module.exports = {
     const { title, frontendQuestionId, difficulty, content, category, topics } =
       req.body;
 
-    // Check if a question with the same title other than itself already exists
-    Question.findOne({ title })
+    // Check if a question with the same title and not soft deleted other than itself already exists
+    Question.findOne({ title, isDeleted: false })
       .then((existingQuestion) => {
         if (existingQuestion && existingQuestion.id != id) {
           return res


### PR DESCRIPTION
This commit addresses the problem where new questions with titles identical to those of previously soft-deleted questions were unable to be created.